### PR TITLE
Add AlbumOrImage endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ $memes = $client->api('memegen')->defaultMemes();
 
 ## Documentation
 
+### Basic information
+
 This client follow the same tree as the [Imgur API](https://api.imgur.com/endpoints).
 
 Here is the list of available _endpoints_: `account`, `album`, `comment`, `custom gallery`, `gallery`, `image`, `conversation`, `notification`, `memegen` & `topic`.
@@ -96,6 +98,8 @@ $client->api('gallery')->randomGalleryImages();
 
 // etc ...
 ```
+
+### Uploading an image
 
 If you want to **upload an image** you can use one of these solutions:
 
@@ -135,11 +139,23 @@ $imageData = [
 $client->api('image')->upload($imageData);
 ```
 
+### Pagination
+
 And about the **pagination**, for any API call that supports pagination and is not explicitly available via the method parameters, it can be achieved by using the `BasicPager` object and passing it as the second parameter in the `api()` call.
 
 ```php
 $pager = new \Imgur\Pager\BasicPager(0, 1);
 $images = $client->api('account', $pager)->images();
+```
+
+### Image id or Album id ?
+
+When you got an Imgur link it's almost impossible to be 100% sure if it's an image or an album.
+That's why we have an endpoint which might fix that by first checking an id as an image and if it's fail, test it as an album:
+
+
+```php
+$data = $client->api('albumOrImage')->find($id);
 ```
 
 ## License

--- a/lib/Imgur/Api/AlbumOrImage.php
+++ b/lib/Imgur/Api/AlbumOrImage.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Imgur\Api;
+
+use Imgur\Exception\ErrorException;
+
+/**
+ * This is a special endpoint.
+ * When you got an Imgur link it's almost impossible to be 100% sure if it's an image or an album.
+ * This endpoint aim to fix that by first checking an id as an image and if it's fail, test it as an album.
+ */
+class AlbumOrImage extends AbstractApi
+{
+    /**
+     * Try to find an image or an album using the given parameter.
+     *
+     * @param string $imageIdOrAlbumId
+     *
+     * @return array Album (@see https://api.imgur.com/models/album) OR Image (@see https://api.imgur.com/models/image)
+     */
+    public function find($imageIdOrAlbumId)
+    {
+        try {
+            return $this->get('image/' . $imageIdOrAlbumId);
+        } catch (ErrorException $e) {
+            if (false === strpos($e->getMessage(), 'Unable to find an image with the id')) {
+                throw $e;
+            }
+        }
+
+        try {
+            return $this->get('album/' . $imageIdOrAlbumId);
+        } catch (ErrorException $e) {
+            if (false === strpos($e->getMessage(), 'Unable to find an album with the id')) {
+                throw $e;
+            }
+        }
+
+        throw new ErrorException('Unable to find an album OR an image with the id, ' . $imageIdOrAlbumId);
+    }
+}

--- a/lib/Imgur/Client.php
+++ b/lib/Imgur/Client.php
@@ -6,6 +6,7 @@ use Imgur\Auth\AuthInterface;
 use Imgur\Exception\InvalidArgumentException;
 use Imgur\HttpClient\HttpClient;
 use Imgur\HttpClient\HttpClientInterface;
+use Imgur\Pager\PagerInterface;
 
 /**
  * PHP Imgur API wrapper.
@@ -54,7 +55,7 @@ class Client
      *
      * @return ApiInterface
      */
-    public function api($name, $pager = null)
+    public function api($name, PagerInterface $pager = null)
     {
         if (!$this->getAccessToken()) {
             $this->sign();
@@ -126,7 +127,7 @@ class Client
      */
     public function getAuthenticationClient()
     {
-        if (empty($this->authenticationClient)) {
+        if (null === $this->authenticationClient) {
             $this->authenticationClient = new Auth\OAuth2(
                 $this->getHttpClient(),
                 $this->getOption('client_id'),

--- a/tests/Api/AlbumOrImageTest.php
+++ b/tests/Api/AlbumOrImageTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Imgur\tests\Api;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Message\Response;
+use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Subscriber\Mock;
+use Imgur\Api\AlbumOrImage;
+use Imgur\Client;
+use Imgur\HttpClient\HttpClient;
+
+class AlbumOrImageTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWithImageId()
+    {
+        $client = new GuzzleClient();
+        $mock = new Mock([
+            new Response(200, ['Content-Type' => 'application/json'], Stream::factory(json_encode(['data' => 'ok !']))),
+        ]);
+        $client->getEmitter()->attach($mock);
+
+        $httpClient = new HttpClient([], $client);
+
+        $client = new Client(null, $httpClient);
+        $api = new AlbumOrImage($client);
+
+        $this->assertSame('ok !', $api->find('ZOY11VC'));
+    }
+
+    public function testWithAlbumId()
+    {
+        $client = new GuzzleClient();
+        $mock = new Mock([
+            new Response(404, ['Content-Type' => 'application/json'], Stream::factory(json_encode([
+                'data' => [
+                    'error' => 'Unable to find an image with the id, 8pCqe',
+                    'request' => '/3/image/8pCqe',
+                    'method' => 'GET',
+                ],
+                'success' => false,
+                'status' => 404,
+            ]))),
+            new Response(200, ['Content-Type' => 'application/json'], Stream::factory(json_encode(['data' => 'ok !']))),
+        ]);
+        $client->getEmitter()->attach($mock);
+
+        $httpClient = new HttpClient([], $client);
+
+        $client = new Client(null, $httpClient);
+        $api = new AlbumOrImage($client);
+
+        $this->assertSame('ok !', $api->find('8pCqe'));
+    }
+
+    /**
+     * @expectedException Imgur\Exception\ErrorException
+     * @expectedExceptionMessage Unable to find an album OR an image with the id
+     */
+    public function testWithBadId()
+    {
+        $client = new GuzzleClient();
+        $mock = new Mock([
+            new Response(404, ['Content-Type' => 'application/json'], Stream::factory(json_encode([
+                'data' => [
+                    'error' => 'Unable to find an image with the id, xxxxxxx',
+                    'request' => '/3/image/xxxxxxx',
+                    'method' => 'GET',
+                ],
+                'success' => false,
+                'status' => 404,
+            ]))),
+            new Response(404, ['Content-Type' => 'application/json'], Stream::factory(json_encode([
+                'data' => [
+                    'error' => 'Unable to find an album with the id, xxxxxxx',
+                    'request' => '/3/album/xxxxxxx',
+                    'method' => 'GET',
+                ],
+                'success' => false,
+                'status' => 404,
+            ]))),
+        ]);
+        $client->getEmitter()->attach($mock);
+
+        $httpClient = new HttpClient([], $client);
+
+        $client = new Client(null, $httpClient);
+        $api = new AlbumOrImage($client);
+
+        $api->find('xxxxxxx');
+    }
+
+    /**
+     * @expectedException Imgur\Exception\ErrorException
+     * @expectedExceptionMessage oops
+     */
+    public function testWithImageIdButBadResponse()
+    {
+        $client = new GuzzleClient();
+        $mock = new Mock([
+            new Response(500, ['Content-Type' => 'application/json'], Stream::factory(json_encode([
+                'data' => [
+                    'error' => 'oops !',
+                    'request' => '/3/image/xxxxxxx',
+                    'method' => 'GET',
+                ],
+                'success' => false,
+                'status' => 404,
+            ]))),
+        ]);
+        $client->getEmitter()->attach($mock);
+
+        $httpClient = new HttpClient([], $client);
+
+        $client = new Client(null, $httpClient);
+        $api = new AlbumOrImage($client);
+
+        $api->find('ZOY11VC');
+    }
+
+    /**
+     * @expectedException Imgur\Exception\ErrorException
+     * @expectedExceptionMessage oops
+     */
+    public function testWithAlbumIdButBadResponse()
+    {
+        $client = new GuzzleClient();
+        $mock = new Mock([
+            new Response(404, ['Content-Type' => 'application/json'], Stream::factory(json_encode([
+                'data' => [
+                    'error' => 'Unable to find an image with the id, xxxxxxx',
+                    'request' => '/3/image/xxxxxxx',
+                    'method' => 'GET',
+                ],
+                'success' => false,
+                'status' => 404,
+            ]))),
+            new Response(500, ['Content-Type' => 'application/json'], Stream::factory(json_encode([
+                'data' => [
+                    'error' => 'oops !',
+                    'request' => '/3/image/xxxxxxx',
+                    'method' => 'GET',
+                ],
+                'success' => false,
+                'status' => 404,
+            ]))),
+        ]);
+        $client->getEmitter()->attach($mock);
+
+        $httpClient = new HttpClient([], $client);
+
+        $client = new Client(null, $httpClient);
+        $api = new AlbumOrImage($client);
+
+        $api->find('8pCqe');
+    }
+}


### PR DESCRIPTION
When you got an Imgur link it's almost impossible to be 100% sure if it's an image or an album.
That's why we have an endpoint which might fix that by first checking an id as an image and if it's fail, test it as an album.

This might fix https://github.com/j0k3r/php-imgur-api-client/issues/6