### PR TITLE
Fix bad 404 received from Imgur

### DIFF
--- a/lib/Imgur/Api/AlbumOrImage.php
+++ b/lib/Imgur/Api/AlbumOrImage.php
@@ -3,6 +3,7 @@
 namespace Imgur\Api;
 
 use Imgur\Exception\ErrorException;
+use Imgur\Exception\ExceptionInterface;
 
 /**
  * This is a special endpoint.
@@ -22,16 +23,16 @@ class AlbumOrImage extends AbstractApi
     {
         try {
             return $this->get('image/' . $imageIdOrAlbumId);
-        } catch (ErrorException $e) {
-            if (false === strpos($e->getMessage(), 'Unable to find an image with the id')) {
+        } catch (ExceptionInterface $e) {
+            if ($e->getCode() !== 404) {
                 throw $e;
             }
         }
 
         try {
             return $this->get('album/' . $imageIdOrAlbumId);
-        } catch (ErrorException $e) {
-            if (false === strpos($e->getMessage(), 'Unable to find an album with the id')) {
+        } catch (ExceptionInterface $e) {
+            if ($e->getCode() !== 404) {
                 throw $e;
             }
         }

--- a/lib/Imgur/Listener/ErrorListener.php
+++ b/lib/Imgur/Listener/ErrorListener.php
@@ -33,7 +33,10 @@ class ErrorListener
         }
 
         if (is_array($responseData) && isset($responseData['data']) && isset($responseData['data']['error'])) {
-            throw new ErrorException('Request to: ' . $responseData['data']['request'] . ' failed with: "' . $responseData['data']['error'] . '"');
+            throw new ErrorException(
+                'Request to: ' . $responseData['data']['request'] . ' failed with: "' . $responseData['data']['error'] . '"',
+                $response->getStatusCode()
+            );
         }
 
         throw new RuntimeException(is_array($responseData) && isset($responseData['message']) ? $responseData['message'] : $responseData, $response->getStatusCode());

--- a/tests/Api/AccountTest.php
+++ b/tests/Api/AccountTest.php
@@ -18,7 +18,7 @@ class AccountTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\ErrorException
+     * @expectedException \Imgur\Exception\ErrorException
      * @expectedExceptionMessage Authentication required
      */
     public function testBaseReal()
@@ -122,7 +122,7 @@ class AccountTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testGalleryFavoritesWrongValues()
@@ -415,7 +415,7 @@ class AccountTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testCommentsWrongValues()
@@ -466,7 +466,7 @@ class AccountTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testCommentIdsWrongValues()

--- a/tests/Api/AlbumOrImageTest.php
+++ b/tests/Api/AlbumOrImageTest.php
@@ -54,7 +54,7 @@ class AlbumOrImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\ErrorException
+     * @expectedException \Imgur\Exception\ErrorException
      * @expectedExceptionMessage Unable to find an album OR an image with the id
      */
     public function testWithBadId()
@@ -91,7 +91,7 @@ class AlbumOrImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\ErrorException
+     * @expectedException \Imgur\Exception\ErrorException
      * @expectedExceptionMessage oops
      */
     public function testWithImageIdButBadResponse()
@@ -119,7 +119,7 @@ class AlbumOrImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\ErrorException
+     * @expectedException \Imgur\Exception\ErrorException
      * @expectedExceptionMessage oops
      */
     public function testWithAlbumIdButBadResponse()

--- a/tests/Api/AlbumTest.php
+++ b/tests/Api/AlbumTest.php
@@ -18,7 +18,7 @@ class AlbumTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\ErrorException
+     * @expectedException \Imgur\Exception\ErrorException
      * @expectedExceptionMessage Authentication required
      */
     public function testBaseReal()

--- a/tests/Api/CommentTest.php
+++ b/tests/Api/CommentTest.php
@@ -18,7 +18,7 @@ class CommentTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\ErrorException
+     * @expectedException \Imgur\Exception\ErrorException
      * @expectedExceptionMessage Authentication required
      */
     public function testBaseReal()
@@ -121,7 +121,7 @@ class CommentTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\MissingArgumentException
+     * @expectedException \Imgur\Exception\MissingArgumentException
      * @expectedExceptionMessage parameters is missing
      */
     public function testCreateParamMissing()
@@ -183,7 +183,7 @@ class CommentTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\MissingArgumentException
+     * @expectedException \Imgur\Exception\MissingArgumentException
      * @expectedExceptionMessage parameters is missing
      */
     public function testCreateReplyParamMissing()
@@ -209,7 +209,7 @@ class CommentTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testVoteWrongVoteValue()

--- a/tests/Api/ConversationTest.php
+++ b/tests/Api/ConversationTest.php
@@ -18,7 +18,7 @@ class ConversationTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\ErrorException
+     * @expectedException \Imgur\Exception\ErrorException
      * @expectedExceptionMessage Authentication required
      */
     public function testBaseReal()
@@ -124,7 +124,7 @@ class ConversationTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\MissingArgumentException
+     * @expectedException \Imgur\Exception\MissingArgumentException
      * @expectedExceptionMessage parameters is missing
      */
     public function testMessageCreateParamMissing()

--- a/tests/Api/CustomGalleryTest.php
+++ b/tests/Api/CustomGalleryTest.php
@@ -18,7 +18,7 @@ class CustomGalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\ErrorException
+     * @expectedException \Imgur\Exception\ErrorException
      * @expectedExceptionMessage Authentication required
      */
     public function testBaseReal()
@@ -115,7 +115,7 @@ class CustomGalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testCustomGalleryWrongSortValue()
@@ -124,7 +124,7 @@ class CustomGalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testCustomGalleryWrongWindowValue()
@@ -152,7 +152,7 @@ class CustomGalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testFilteredWrongSortValue()
@@ -161,7 +161,7 @@ class CustomGalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testFilteredWrongWindowValue()

--- a/tests/Api/GalleryTest.php
+++ b/tests/Api/GalleryTest.php
@@ -18,7 +18,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\ErrorException
+     * @expectedException \Imgur\Exception\ErrorException
      * @expectedExceptionMessage Authentication required
      */
     public function testBaseReal()
@@ -132,7 +132,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testGalleryWrongSortValue()
@@ -141,7 +141,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testGalleryWrongSectionValue()
@@ -150,7 +150,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testGalleryWrongWindowValue()
@@ -180,7 +180,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testMemesSubgalleryWrongSortValue()
@@ -189,7 +189,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testMemesSubgalleryWrongWindowValue()
@@ -238,7 +238,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testSubredditGalleriesWrongSortValue()
@@ -247,7 +247,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testSubredditGalleriesWrongWindowValue()
@@ -296,7 +296,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testGalleryTagWrongSortValue()
@@ -305,7 +305,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testGalleryTagWrongWindowValue()
@@ -369,7 +369,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testGalleryVoteTagWrongVoteValue()
@@ -399,7 +399,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testSearchWrongValues()
@@ -446,7 +446,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\MissingArgumentException
+     * @expectedException \Imgur\Exception\MissingArgumentException
      * @expectedExceptionMessage parameters is missing
      */
     public function testSubmitToGalleryParamMissing()
@@ -563,7 +563,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testVoteWrongVoteValue()
@@ -593,7 +593,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testCommentsWrongValues()
@@ -638,7 +638,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\MissingArgumentException
+     * @expectedException \Imgur\Exception\MissingArgumentException
      * @expectedExceptionMessage parameters is missing
      */
     public function testCreateCommentParamMissing()
@@ -664,7 +664,7 @@ class GalleryTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\MissingArgumentException
+     * @expectedException \Imgur\Exception\MissingArgumentException
      * @expectedExceptionMessage parameters is missing
      */
     public function testCreateReplyParamMissing()

--- a/tests/Api/ImageTest.php
+++ b/tests/Api/ImageTest.php
@@ -18,7 +18,7 @@ class ImageTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\ErrorException
+     * @expectedException \Imgur\Exception\ErrorException
      * @expectedExceptionMessage Authentication required
      */
     public function testBaseReal()
@@ -150,7 +150,7 @@ class ImageTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testUploadWithBadType()
@@ -159,7 +159,7 @@ class ImageTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\MissingArgumentException
+     * @expectedException \Imgur\Exception\MissingArgumentException
      * @expectedExceptionMessage parameters is missing
      */
     public function testUploadWithUrlParamMissing()

--- a/tests/Api/MemegenTest.php
+++ b/tests/Api/MemegenTest.php
@@ -18,7 +18,7 @@ class MemegenTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\ErrorException
+     * @expectedException \Imgur\Exception\ErrorException
      * @expectedExceptionMessage Authentication required
      */
     public function testBaseReal()

--- a/tests/Api/NotificationTest.php
+++ b/tests/Api/NotificationTest.php
@@ -18,7 +18,7 @@ class NotificationTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\ErrorException
+     * @expectedException \Imgur\Exception\ErrorException
      * @expectedExceptionMessage Authentication required
      */
     public function testBaseReal()

--- a/tests/Api/TopicTest.php
+++ b/tests/Api/TopicTest.php
@@ -18,7 +18,7 @@ class TopicTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\ErrorException
+     * @expectedException \Imgur\Exception\ErrorException
      * @expectedExceptionMessage Authentication required
      */
     public function testBaseReal()
@@ -169,7 +169,7 @@ class TopicTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testGalleryTopicWrongSortValue()
@@ -178,7 +178,7 @@ class TopicTest extends ApiTestCase
     }
 
     /**
-     * @expectedException Imgur\Exception\InvalidArgumentException
+     * @expectedException \Imgur\Exception\InvalidArgumentException
      * @expectedExceptionMessage is wrong. Possible values are
      */
     public function testGalleryTopicWrongWindowValue()

--- a/tests/Listener/ErrorListenerTest.php
+++ b/tests/Listener/ErrorListenerTest.php
@@ -91,7 +91,7 @@ class ErrorListenerTest extends \PHPUnit_Framework_TestCase
         $response = $this->getMockBuilder('GuzzleHttp\Message\ResponseInterface')
             ->disableOriginalConstructor()
             ->getMock();
-        $response->expects($this->once())
+        $response->expects($this->exactly(2))
             ->method('getStatusCode')
             ->will($this->returnValue(429));
         $response->expects($this->once())


### PR DESCRIPTION
Looks like Imgur now return the default 404 (in HTML format) instead of JSON structured response when it does not find an album or an image.
So I used a different method to determine a bad exception from them, using the status code instead of the exception name.