### PR TITLE
3.x / Handle error when uploading too fast

### DIFF
--- a/lib/Imgur/Middleware/ErrorMiddleware.php
+++ b/lib/Imgur/Middleware/ErrorMiddleware.php
@@ -71,9 +71,15 @@ class ErrorMiddleware
         }
 
         if (\is_array($responseData) && isset($responseData['data']) && isset($responseData['data']['error'])) {
-            $message = 'Request failed with: "' . $responseData['data']['error'] . '"';
+            $errorMessage = $responseData['data']['error'];
+            // when uploading too fast, error is an array
+            if (\is_array($responseData['data']['error']) && isset($responseData['data']['error']['message'])) {
+                $errorMessage = $responseData['data']['error']['message'];
+            }
+
+            $message = 'Request failed with: "' . $errorMessage . '"';
             if (isset($responseData['data']['request'])) {
-                $message = 'Request to: ' . $responseData['data']['request'] . ' failed with: "' . $responseData['data']['error'] . '"';
+                $message = 'Request to: ' . $responseData['data']['request'] . ' failed with: "' . $errorMessage . '"';
             }
 
             throw new ErrorException($message, $response->getStatusCode());


### PR DESCRIPTION
Fix error message when user is uploading too fast.
Related https://github.com/j0k3r/php-imgur-api-client/issues/23