### PR TITLE
2.x / Handle error when uploading too fast

### DIFF
--- a/lib/Imgur/Listener/ErrorListener.php
+++ b/lib/Imgur/Listener/ErrorListener.php
@@ -33,9 +33,15 @@ class ErrorListener
         }
 
         if (\is_array($responseData) && isset($responseData['data']) && isset($responseData['data']['error'])) {
-            $message = 'Request failed with: "' . $responseData['data']['error'] . '"';
+            $errorMessage = $responseData['data']['error'];
+            // when uploading too fast, error is an array
+            if (\is_array($responseData['data']['error']) && isset($responseData['data']['error']['message'])) {
+                $errorMessage = $responseData['data']['error']['message'];
+            }
+
+            $message = 'Request failed with: "' . $errorMessage . '"';
             if (isset($responseData['data']['request'])) {
-                $message = 'Request to: ' . $responseData['data']['request'] . ' failed with: "' . $responseData['data']['error'] . '"';
+                $message = 'Request to: ' . $responseData['data']['request'] . ' failed with: "' . $errorMessage . '"';
             }
 
             throw new ErrorException($message, $response->getStatusCode());

--- a/lib/Imgur/Listener/ErrorListener.php
+++ b/lib/Imgur/Listener/ErrorListener.php
@@ -35,8 +35,14 @@ class ErrorListener
         if (\is_array($responseData) && isset($responseData['data']) && isset($responseData['data']['error'])) {
             $errorMessage = $responseData['data']['error'];
             // when uploading too fast, error is an array
-            if (\is_array($responseData['data']['error']) && isset($responseData['data']['error']['message'])) {
-                $errorMessage = $responseData['data']['error']['message'];
+            if (\is_array($responseData['data']['error'])) {
+                $errorMessage = '';
+
+                if (isset($responseData['data']['error']['message'])) {
+                    $errorMessage = $responseData['data']['error']['message'];
+                } elseif (isset($responseData['data']['error']['code'])) {
+                    $errorMessage = 'Error code: ' . $responseData['data']['error']['code'];
+                }
             }
 
             $message = 'Request failed with: "' . $errorMessage . '"';

--- a/tests/Listener/ErrorListenerTest.php
+++ b/tests/Listener/ErrorListenerTest.php
@@ -155,6 +155,42 @@ class ErrorListenerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @expectedException \Imgur\Exception\ErrorException
+     * @expectedExceptionMessage Request to: /3/image.json failed with: "You are uploading too fast. Please wait 59 more minutes."
+     */
+    public function testErrorUploadingTooFast()
+    {
+        $response = $this->getMockBuilder('GuzzleHttp\Message\ResponseInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->will($this->returnValue(429));
+        $response->expects($this->once())
+            ->method('getBody')
+            ->will($this->returnValue(json_encode(['status' => 400, 'success' => false, 'data' => ['error' => ['code' => 429, 'message' => 'You are uploading too fast. Please wait 59 more minutes.', 'type' => 'ImgurException', 'exception' => []], 'request' => '/3/image.json', 'method' => 'POST']])));
+        $response->expects($this->at(1))
+            ->method('getHeader')
+            ->with('X-RateLimit-UserRemaining')
+            ->will($this->returnValue(9));
+        $response->expects($this->at(2))
+            ->method('getHeader')
+            ->with('X-RateLimit-UserLimit')
+            ->will($this->returnValue(10));
+        $response->expects($this->at(3))
+            ->method('getHeader')
+            ->with('X-RateLimit-ClientRemaining')
+            ->will($this->returnValue(9));
+        $response->expects($this->at(4))
+            ->method('getHeader')
+            ->with('X-RateLimit-ClientLimit')
+            ->will($this->returnValue(10));
+
+        $listener = new ErrorListener();
+        $listener->error($this->getEventMock($response));
+    }
+
+    /**
      * @expectedException \Imgur\Exception\RuntimeException
      * @expectedExceptionMessage hihi
      */

--- a/tests/Listener/ErrorListenerTest.php
+++ b/tests/Listener/ErrorListenerTest.php
@@ -191,6 +191,42 @@ class ErrorListenerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @expectedException \Imgur\Exception\ErrorException
+     * @expectedExceptionMessage Request to: /3/image.json failed with: "Error code: 666"
+     */
+    public function testErrorNoMessageInError()
+    {
+        $response = $this->getMockBuilder('GuzzleHttp\Message\ResponseInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->will($this->returnValue(429));
+        $response->expects($this->once())
+            ->method('getBody')
+            ->will($this->returnValue(json_encode(['status' => 400, 'success' => false, 'data' => ['error' => ['code' => 666, 'type' => 'ImgurException', 'exception' => []], 'request' => '/3/image.json', 'method' => 'POST']])));
+        $response->expects($this->at(1))
+            ->method('getHeader')
+            ->with('X-RateLimit-UserRemaining')
+            ->will($this->returnValue(9));
+        $response->expects($this->at(2))
+            ->method('getHeader')
+            ->with('X-RateLimit-UserLimit')
+            ->will($this->returnValue(10));
+        $response->expects($this->at(3))
+            ->method('getHeader')
+            ->with('X-RateLimit-ClientRemaining')
+            ->will($this->returnValue(9));
+        $response->expects($this->at(4))
+            ->method('getHeader')
+            ->with('X-RateLimit-ClientLimit')
+            ->will($this->returnValue(10));
+
+        $listener = new ErrorListener();
+        $listener->error($this->getEventMock($response));
+    }
+
+    /**
      * @expectedException \Imgur\Exception\RuntimeException
      * @expectedExceptionMessage hihi
      */


### PR DESCRIPTION
Fix error message when user is uploading too fast.
Related https://github.com/j0k3r/php-imgur-api-client/issues/23