### PR TITLE
Apply the ternary to null operator

### DIFF
--- a/tests/HttpClient/HttpClientTest.php
+++ b/tests/HttpClient/HttpClientTest.php
@@ -294,6 +294,6 @@ class TestHttpClient extends HttpClient
      */
     public function getOption(string $name, string $default = null)
     {
-        return isset($this->options[$name]) ? $this->options[$name] : $default;
+        return $this->options[$name] ?? $default;
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `??` operator to replace the origin ternary null operator.