### PR TITLE
Add phpstan/extension-installer to allow plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,9 @@
         "symfony/phpunit-bridge": "^6.0"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }


### PR DESCRIPTION
# Changed log

- Add the plugin inside the `allow-plugins` setting block in the `composer.json` file. It can avoid the following message:

```
- Installing phpstan/phpstan (1.10.34): Extracting archive
phpstan/extension-installer contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "phpstan/extension-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
```
